### PR TITLE
Updates :-

### DIFF
--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -64,6 +64,8 @@ func (app *Config) errorJSON(w http.ResponseWriter, err error, status ...int) er
 }
 
 func registerInterfaces() {
+	gob.Register(&[]interface{}{})
+	gob.Register(&map[string]interface{}{})
 	gob.Register(&tasks.Request{})
 	gob.Register(&template.Person{})
 	gob.Register(&template.SmallTemplate{})
@@ -77,6 +79,7 @@ func registerInterfaces() {
 	gob.Register(&task_result.TaskResult{})
 	gob.Register(&task_state.TaskState{})
 	gob.Register(&tasks.ReadTask{})
+	gob.Register(&tasks.SingleInsertTask{})
 
 	r := generate.Register{}
 	for _, i := range r.HelperStruct() {

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -27,13 +27,14 @@ func (app *Config) routes() http.Handler {
 
 	mux.Get("/", app.testServer)
 	mux.Post("/result", app.taskResult)
-	mux.Post("/insert", app.insertTask)
+	mux.Post("/bulk-insert", app.insertTask)
 	mux.Post("/fast-insert", app.fastInsertTask)
-	mux.Post("/delete", app.deleteTask)
-	mux.Post("/upsert", app.upsertTask)
+	mux.Post("/bulk-delete", app.deleteTask)
+	mux.Post("/bulk-upsert", app.upsertTask)
 	mux.Post("/validate", app.validateTask)
 	mux.Post("/clear_data", app.clearRequestFromServer)
-	mux.Post("/read", app.readTask)
+	mux.Post("/bulk-read", app.readTask)
+	mux.Post("/single-insert", app.singleInsertTask)
 
 	return mux
 }

--- a/internal/generate/register.go
+++ b/internal/generate/register.go
@@ -15,25 +15,28 @@ type Register struct {
 
 func (r *Register) RegisteredTasks() map[string]TaskRegister {
 	return map[string]TaskRegister{
-		"/insert":      {"POST", &tasks.InsertTask{}},
-		"/fast-insert": {"Post", &tasks.FastInsertTask{}},
-		"/delete":      {"POST", &tasks.DeleteTask{}},
-		"/upsert":      {"POST", &tasks.UpsertTask{}},
-		"/validate":    {"POST", &tasks.ValidateTask{}},
-		"/result":      {"POST", &tasks.TaskResult{}},
-		"/clear_data":  {"POST", &tasks.ClearTask{}},
-		"/read":        {"POST", &tasks.ReadTask{}},
+		"/bulk-insert":   {"POST", &tasks.InsertTask{}},
+		"/fast-insert":   {"Post", &tasks.FastInsertTask{}},
+		"/bulk-delete":   {"POST", &tasks.DeleteTask{}},
+		"/bulk-upsert":   {"POST", &tasks.UpsertTask{}},
+		"/validate":      {"POST", &tasks.ValidateTask{}},
+		"/result":        {"POST", &tasks.TaskResult{}},
+		"/clear_data":    {"POST", &tasks.ClearTask{}},
+		"/bulk-read":     {"POST", &tasks.ReadTask{}},
+		"/single-insert": {"POST", &tasks.SingleInsertTask{}},
 	}
 }
 
 func (r *Register) HelperStruct() map[string]any {
 	return map[string]any{
-		"clusterConfig":     &sdk.ClusterConfig{},
-		"compressionConfig": &sdk.CompressionConfig{},
-		"timeoutsConfig":    &sdk.TimeoutsConfig{},
-		"operationConfig":   &tasks.OperationConfig{},
-		"insertOptions":     &tasks.InsertOptions{},
-		"removeOptions":     &tasks.RemoveOptions{},
+		"clusterConfig":         &sdk.ClusterConfig{},
+		"compressionConfig":     &sdk.CompressionConfig{},
+		"timeoutsConfig":        &sdk.TimeoutsConfig{},
+		"operationConfig":       &tasks.OperationConfig{},
+		"insertOptions":         &tasks.InsertOptions{},
+		"removeOptions":         &tasks.RemoveOptions{},
+		"singleOperationConfig": &tasks.SingleOperationConfig{},
+		"keyValue":              &tasks.KeyValue{},
 	}
 
 }

--- a/internal/sdk/cluster_collection_manager_test.go
+++ b/internal/sdk/cluster_collection_manager_test.go
@@ -15,7 +15,7 @@ func TestConfigConnectionManager(t *testing.T) {
 	cConfig := &ClusterConfig{
 		Username:          "Administrator",
 		Password:          "password",
-		ConnectionString:  "couchbase://172.23.136.104",
+		ConnectionString:  "couchbase://172.23.120.59",
 		CompressionConfig: CompressionConfig{},
 		TimeoutsConfig:    TimeoutsConfig{},
 	}

--- a/internal/tasks/helper.go
+++ b/internal/tasks/helper.go
@@ -13,6 +13,7 @@ const (
 	UpsertOperation       string = "upsert"
 	ValidateOperation     string = "validate"
 	ReadOperation         string = "read"
+	SingleInsertOperation string = "singleInsert"
 )
 
 const (
@@ -26,7 +27,7 @@ const (
 	DefaultPassword                           string = "password"
 )
 
-// getDurability returns gocb.DurabilityLevel required for doc loading operation
+// getDurability returns gocb.DurabilityLevel required for Doc loading operation
 func getDurability(durability string) gocb.DurabilityLevel {
 	switch durability {
 	case DurabilityLevelMajority:
@@ -55,6 +56,31 @@ type OperationConfig struct {
 	Start            int64    `json:"start" doc:"true"`
 	End              int64    `json:"end" doc:"true"`
 	FieldsToChange   []string `json:"fieldsToChange" doc:"true"`
+}
+
+type KeyValue struct {
+	Key string      `json:"key" doc:"true"`
+	Doc interface{} `json:"value" doc:"true"`
+}
+
+type SingleOperationConfig struct {
+	KeyValue         []KeyValue `json:"keyValue" doc:"true"`
+	ReadYourOwnWrite bool       `json:"readYourOwnWrite,omitempty" doc:"true"`
+}
+
+func configSingleOperationConfig(s *SingleOperationConfig) error {
+	if s == nil {
+		return fmt.Errorf("unable to parse SingleOperationConfig")
+	}
+
+	var finalKeyValue []KeyValue
+	for _, kv := range s.KeyValue {
+		if kv.Key != "" {
+			finalKeyValue = append(finalKeyValue, kv)
+		}
+	}
+	s.KeyValue = finalKeyValue
+	return nil
 }
 
 // configureOperationConfig configures and validate the OperationConfig

--- a/internal/tasks/task_bulk_delete.go
+++ b/internal/tasks/task_bulk_delete.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 	"github.com/couchbase/gocb/v2"
 	"github.com/couchbaselabs/sirius/internal/docgenerator"
@@ -8,20 +9,18 @@ import (
 	"github.com/couchbaselabs/sirius/internal/task_result"
 	"github.com/couchbaselabs/sirius/internal/task_state"
 	"github.com/couchbaselabs/sirius/internal/template"
-	"github.com/jaswdr/faker"
 	"golang.org/x/sync/errgroup"
 	"log"
-	"math/rand"
 	"time"
 )
 
-type UpsertTask struct {
+type DeleteTask struct {
 	IdentifierToken string                  `json:"identifierToken" doc:"true"`
 	ClusterConfig   *sdk.ClusterConfig      `json:"clusterConfig" doc:"true"`
 	Bucket          string                  `json:"bucket" doc:"true"`
 	Scope           string                  `json:"scope,omitempty" doc:"true"`
 	Collection      string                  `json:"collection,omitempty" doc:"true"`
-	InsertOptions   *InsertOptions          `json:"insertOptions,omitempty" doc:"true"`
+	RemoveOptions   *RemoveOptions          `json:"removeOptions,omitempty" doc:"true"`
 	OperationConfig *OperationConfig        `json:"operationConfig,omitempty" doc:"true"`
 	Template        interface{}             `json:"-" doc:"false"`
 	Operation       string                  `json:"operation" doc:"false"`
@@ -33,7 +32,12 @@ type UpsertTask struct {
 	req             *Request                `json:"-" doc:"false"`
 }
 
-func (task *UpsertTask) BuildIdentifier() string {
+func (task *DeleteTask) Describe() string {
+	return `Delete task deletes documents in bulk into a bucket.
+The task will delete documents from [start,end] inclusive.`
+}
+
+func (task *DeleteTask) BuildIdentifier() string {
 	if task.ClusterConfig == nil {
 		task.ClusterConfig = &sdk.ClusterConfig{}
 		log.Println("build Identifier have received nil ClusterConfig")
@@ -51,39 +55,36 @@ func (task *UpsertTask) BuildIdentifier() string {
 		task.Collection)
 }
 
-func (task *UpsertTask) Describe() string {
-	return `Upsert task mutates documents in bulk into a bucket.
-The task will update the fields in a documents ranging from [start,end] inclusive.
-We need to share the fields we want to update in a json document using SQL++ syntax.`
-}
-
-func (task *UpsertTask) CheckIfPending() bool {
+func (task *DeleteTask) CheckIfPending() bool {
 	return task.TaskPending
 }
 
-func (task *UpsertTask) Config(req *Request, seed int64, seedEnd int64, reRun bool) (int64, error) {
+// Config checks the validity of DeleteTask
+func (task *DeleteTask) Config(req *Request, seed int64, seedEnd int64, reRun bool) (int64, error) {
 	task.TaskPending = true
 	task.req = req
 
 	if task.req == nil {
+		task.TaskPending = false
 		return 0, fmt.Errorf("request.Request struct is nil")
 	}
 
 	task.req.ReconnectionManager()
 	if _, err := task.req.connectionManager.GetCluster(task.ClusterConfig); err != nil {
+		task.TaskPending = false
 		return 0, err
 	}
 
 	if !reRun {
 		task.ResultSeed = time.Now().UnixNano()
-		task.Operation = UpsertOperation
+		task.Operation = DeleteOperation
 		task.Result = task_result.ConfigTaskResult(task.Operation, task.ResultSeed)
 
 		if task.IdentifierToken == "" {
-			return 0, fmt.Errorf("identifier token is missing")
+			task.Result.ErrorOther = "identifier token is missing"
 		}
 
-		if err := configInsertOptions(task.InsertOptions); err != nil {
+		if err := configRemoveOptions(task.RemoveOptions); err != nil {
 			task.Result.ErrorOther = err.Error()
 		}
 
@@ -108,13 +109,13 @@ func (task *UpsertTask) Config(req *Request, seed int64, seedEnd int64, reRun bo
 	return task.ResultSeed, nil
 }
 
-func (task *UpsertTask) tearUp() error {
+func (task *DeleteTask) tearUp() error {
 	task.State.StopStoringState()
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()
 }
 
-func (task *UpsertTask) Do() error {
+func (task *DeleteTask) Do() error {
 
 	if task.Result != nil && task.Result.ErrorOther != "" {
 		log.Println(task.Result.ErrorOther)
@@ -136,29 +137,25 @@ func (task *UpsertTask) Do() error {
 			log.Println("not able to save Result into ", task.ResultSeed)
 			return err
 		}
-		task.State.AddRangeToErrSet(task.OperationConfig.Start, task.OperationConfig.End)
 		return task.tearUp()
 	}
 
-	task.gen = docgenerator.ConfigGenerator(task.OperationConfig.DocType, task.OperationConfig.KeyPrefix,
-		task.OperationConfig.KeySuffix, task.State.SeedStart, task.State.SeedEnd,
-		template.InitialiseTemplate(task.OperationConfig.TemplateName))
+	task.gen = docgenerator.ConfigGenerator("", task.State.KeyPrefix, task.State.KeySuffix,
+		task.State.SeedStart, task.State.SeedEnd, template.InitialiseTemplate(task.State.TemplateName))
 
-	upsertDocuments(task, collection)
-
+	deleteDocuments(task, collection)
 	task.Result.Success = task.OperationConfig.End - task.OperationConfig.Start - task.Result.Failure
 
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.State.ClearCompletedKeyStates()
+
+	task.State.ClearErrorKeyStates()
 	return task.tearUp()
 }
 
-func upsertDocuments(task *UpsertTask, collection *gocb.Collection) {
-	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
-	dataChannel := make(chan int64, MaxConcurrentRoutines)
-	maxKey := int64(-1)
+// deleteDocuments delete the document stored on a host from start to end.
+func deleteDocuments(task *DeleteTask, collection *gocb.Collection) {
 	skip := make(map[int64]struct{})
 	for _, offset := range task.State.KeyStates.Completed {
 		skip[offset] = struct{}{}
@@ -170,14 +167,15 @@ func upsertDocuments(task *UpsertTask, collection *gocb.Collection) {
 	if err != nil {
 		return
 	}
-
+	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
+	dataChannel := make(chan int64, MaxConcurrentRoutines)
 	group := errgroup.Group{}
+
 	for i := task.OperationConfig.Start; i < task.OperationConfig.End; i++ {
 		routineLimiter <- struct{}{}
 		dataChannel <- i
 
 		group.Go(func() error {
-			var err error
 			offset := <-dataChannel
 			key := task.req.Seed + offset
 			docId := task.gen.BuildKey(key)
@@ -189,38 +187,26 @@ func upsertDocuments(task *UpsertTask, collection *gocb.Collection) {
 				<-routineLimiter
 				return fmt.Errorf("alreday deleted docID on " + docId)
 			}
-			fake := faker.NewWithSeed(rand.NewSource(key))
-			originalDoc, err := task.gen.Template.GenerateDocument(&fake, task.State.DocumentSize)
-			if err != nil {
+			if key > task.req.SeedEnd || key < task.req.Seed {
+				task.Result.IncrementFailure(docId, nil, errors.New("docId out of bound"))
 				<-routineLimiter
-
-				return err
+				return fmt.Errorf("docId out of bound")
 			}
-			originalDoc, err = task.req.retracePreviousMutations(offset, originalDoc, *task.gen, &fake, task.ResultSeed)
-			if err != nil {
-				task.Result.IncrementFailure(docId, originalDoc, err)
-				<-routineLimiter
-				return err
-			}
-			docUpdated, err := task.gen.Template.UpdateDocument(task.OperationConfig.FieldsToChange, originalDoc, &fake)
-			_, err = collection.Upsert(docId, docUpdated, &gocb.UpsertOptions{
-				DurabilityLevel: getDurability(task.InsertOptions.Durability),
-				PersistTo:       task.InsertOptions.PersistTo,
-				ReplicateTo:     task.InsertOptions.ReplicateTo,
-				Timeout:         time.Duration(task.InsertOptions.Timeout) * time.Second,
-				Expiry:          time.Duration(task.InsertOptions.Expiry) * time.Second,
+			_, err := collection.Remove(docId, &gocb.RemoveOptions{
+				Cas:             gocb.Cas(task.RemoveOptions.Cas),
+				PersistTo:       task.RemoveOptions.PersistTo,
+				ReplicateTo:     task.RemoveOptions.ReplicateTo,
+				DurabilityLevel: getDurability(task.RemoveOptions.Durability),
+				Timeout:         time.Duration(task.RemoveOptions.Timeout) * time.Second,
 			})
 			if err != nil {
-				task.Result.IncrementFailure(docId, docUpdated, err)
+				task.Result.IncrementFailure(docId, nil, err)
 				task.State.StateChannel <- task_state.StateHelper{Status: task_state.ERR, Offset: offset}
 				<-routineLimiter
 				return err
 			}
 
 			task.State.StateChannel <- task_state.StateHelper{Status: task_state.COMPLETED, Offset: offset}
-			if offset > maxKey {
-				maxKey = offset
-			}
 			<-routineLimiter
 			return nil
 		})
@@ -228,6 +214,5 @@ func upsertDocuments(task *UpsertTask, collection *gocb.Collection) {
 	_ = group.Wait()
 	close(routineLimiter)
 	close(dataChannel)
-	task.req.checkAndUpdateSeedEnd(maxKey)
 	log.Println("completed :- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
 }

--- a/internal/tasks/task_bulk_insert.go
+++ b/internal/tasks/task_bulk_insert.go
@@ -71,11 +71,13 @@ func (task *InsertTask) Config(req *Request, seed int64, seedEnd int64, reRun bo
 	task.req = req
 
 	if task.req == nil {
+		task.TaskPending = false
 		return 0, fmt.Errorf("request.Request struct is nil")
 	}
 
 	task.req.ReconnectionManager()
 	if _, err := task.req.connectionManager.GetCluster(task.ClusterConfig); err != nil {
+		task.TaskPending = false
 		return 0, err
 	}
 

--- a/internal/tasks/task_clear.go
+++ b/internal/tasks/task_clear.go
@@ -12,7 +12,7 @@ type ClearTask struct {
 	Bucket          string `json:"bucket,omitempty" doc:"true"`
 	Scope           string `json:"scope,omitempty" doc:"true"`
 	Collection      string `json:"collection,omitempty" doc:"true"`
-	TaskPending     bool
+	TaskPending     bool   `json:"-" doc"false"`
 }
 
 func (task *ClearTask) Describe() string {

--- a/internal/tasks/task_single_create.go
+++ b/internal/tasks/task_single_create.go
@@ -1,0 +1,220 @@
+package tasks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/couchbase/gocb/v2"
+	"github.com/couchbaselabs/sirius/internal/sdk"
+	"github.com/couchbaselabs/sirius/internal/task_result"
+	"golang.org/x/sync/errgroup"
+	"log"
+	"time"
+)
+
+type SingleInsertTask struct {
+	IdentifierToken string                  `json:"identifierToken" doc:"true"`
+	ClusterConfig   *sdk.ClusterConfig      `json:"clusterConfig" doc:"true"`
+	Bucket          string                  `json:"bucket" doc:"true"`
+	Scope           string                  `json:"scope,omitempty" doc:"true"`
+	Collection      string                  `json:"collection,omitempty" doc:"true"`
+	InsertOptions   *InsertOptions          `json:"insertOptions,omitempty" doc:"true"`
+	OperationConfig *SingleOperationConfig  `json:"singleOperationConfig" doc:"true"`
+	Operation       string                  `json:"operation" doc:"false"`
+	ResultSeed      int64                   `json:"resultSeed" doc:"false"`
+	TaskPending     bool                    `json:"taskPending" doc:"false"`
+	Result          *task_result.TaskResult `json:"Result" doc:"false"`
+	req             *Request                `json:"-" doc:"false"`
+}
+
+func (task *SingleInsertTask) Describe() string {
+	return "Single insert task uploads key value in CB.\n"
+}
+
+func (task *SingleInsertTask) BuildIdentifier() string {
+	if task.ClusterConfig == nil {
+		task.ClusterConfig = &sdk.ClusterConfig{}
+		log.Println("build Identifier have received nil ClusterConfig")
+	}
+	if task.Bucket == "" {
+		task.Bucket = DefaultBucket
+	}
+	if task.Scope == "" {
+		task.Scope = DefaultScope
+	}
+	if task.Collection == "" {
+		task.Collection = DefaultCollection
+	}
+	return fmt.Sprintf("%s-%s-%s-%s-%s", task.ClusterConfig.Username, task.IdentifierToken, task.Bucket, task.Scope,
+		task.Collection)
+}
+
+func (task *SingleInsertTask) CheckIfPending() bool {
+	return task.TaskPending
+}
+
+// Config configures  the insert task
+func (task *SingleInsertTask) Config(req *Request, seed int64, seedEnd int64, reRun bool) (int64, error) {
+	task.TaskPending = true
+	task.req = req
+
+	if task.req == nil {
+		task.TaskPending = false
+		return 0, fmt.Errorf("request.Request struct is nil")
+	}
+
+	task.req.ReconnectionManager()
+	if _, err := task.req.connectionManager.GetCluster(task.ClusterConfig); err != nil {
+		task.TaskPending = false
+		return 0, err
+	}
+
+	if !reRun {
+		task.ResultSeed = time.Now().UnixNano()
+		task.Operation = SingleInsertOperation
+		task.Result = task_result.ConfigTaskResult(task.Operation, task.ResultSeed)
+
+		if task.IdentifierToken == "" {
+			task.Result.ErrorOther = "identifier token is missing"
+		}
+
+		if err := configInsertOptions(task.InsertOptions); err != nil {
+			task.Result.ErrorOther = err.Error()
+		}
+
+		if err := configSingleOperationConfig(task.OperationConfig); err != nil {
+			task.Result.ErrorOther = err.Error()
+		}
+	} else {
+		log.Println("retrying :- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
+	}
+	return task.ResultSeed, nil
+}
+
+func (task *SingleInsertTask) tearUp() error {
+	task.TaskPending = false
+	return task.req.SaveRequestIntoFile()
+}
+
+func (task *SingleInsertTask) Do() error {
+
+	if task.Result != nil && task.Result.ErrorOther != "" {
+		log.Println(task.Result.ErrorOther)
+		if err := task.Result.SaveResultIntoFile(); err != nil {
+			log.Println("not able to save Result into ", task.ResultSeed)
+			return err
+		}
+		return task.tearUp()
+	} else {
+		task.Result = task_result.ConfigTaskResult(task.Operation, task.ResultSeed)
+	}
+
+	collection, err1 := task.req.connectionManager.GetCollection(task.ClusterConfig, task.Bucket, task.Scope,
+		task.Collection)
+
+	if err1 != nil {
+		task.Result.ErrorOther = err1.Error()
+		if err := task.Result.SaveResultIntoFile(); err != nil {
+			log.Println("not able to save Result into ", task.ResultSeed)
+			return err
+		}
+		return task.tearUp()
+	}
+
+	singleInsertDocuments(task, collection)
+
+	task.Result.Success = int64(len(task.OperationConfig.KeyValue)) - task.Result.Failure
+
+	if err := task.Result.SaveResultIntoFile(); err != nil {
+		log.Println("not able to save Result into ", task.ResultSeed)
+	}
+
+	return task.tearUp()
+}
+
+// insertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
+func singleInsertDocuments(task *SingleInsertTask, collection *gocb.Collection) {
+
+	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
+	dataChannel := make(chan interface{}, MaxConcurrentRoutines)
+
+	group := errgroup.Group{}
+
+	for _, data := range task.OperationConfig.KeyValue {
+		routineLimiter <- struct{}{}
+		dataChannel <- data
+
+		group.Go(func() error {
+			keyValue := <-dataChannel
+			kV, ok := keyValue.(KeyValue)
+			if !ok {
+				task.Result.IncrementFailure("unknownDocId", struct{}{},
+					errors.New("unable to decode Key Value for single crud"))
+				<-routineLimiter
+				return errors.New("unable to decode Key Value for single crud")
+			}
+
+			_, err := collection.Insert(kV.Key, kV.Doc, &gocb.InsertOptions{
+				DurabilityLevel: getDurability(task.InsertOptions.Durability),
+				PersistTo:       task.InsertOptions.PersistTo,
+				ReplicateTo:     task.InsertOptions.ReplicateTo,
+				Timeout:         time.Duration(task.InsertOptions.Timeout) * time.Second,
+				Expiry:          time.Duration(task.InsertOptions.Expiry) * time.Second,
+			})
+			if task.OperationConfig.ReadYourOwnWrite {
+
+				var resultFromHost map[string]interface{}
+				result, err := collection.Get(kV.Key, nil)
+				if err != nil {
+					task.Result.IncrementFailure(kV.Key, kV.Doc, err)
+					<-routineLimiter
+					return err
+				}
+				if err := result.Content(&resultFromHost); err != nil {
+					task.Result.IncrementFailure(kV.Key, kV.Doc, err)
+					<-routineLimiter
+					return err
+				}
+
+				resultFromHostBytes, err := json.Marshal(resultFromHost)
+				if err != nil {
+					task.Result.IncrementFailure(kV.Key, kV.Doc, err)
+					<-routineLimiter
+					return err
+				}
+				resultFromDocBytes, err := json.Marshal(kV.Doc)
+				if err != nil {
+					task.Result.IncrementFailure(kV.Key, kV.Doc, err)
+					<-routineLimiter
+					return err
+				}
+
+				if !bytes.Equal(resultFromHostBytes, resultFromDocBytes) {
+					task.Result.IncrementFailure(kV.Key, kV.Doc, errors.New("document mismatch on RYOW"))
+					<-routineLimiter
+					return err
+				}
+			} else {
+				if err != nil {
+					if errors.Is(err, gocb.ErrDocumentExists) {
+						<-routineLimiter
+						return nil
+					} else {
+						task.Result.IncrementFailure(kV.Key, kV.Doc, err)
+						<-routineLimiter
+						return err
+					}
+				}
+			}
+
+			<-routineLimiter
+			return nil
+		})
+	}
+
+	_ = group.Wait()
+	close(routineLimiter)
+	close(dataChannel)
+	log.Println("completed :- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
+}

--- a/internal/tasks/task_validate.go
+++ b/internal/tasks/task_validate.go
@@ -70,11 +70,13 @@ func (task *ValidateTask) Config(req *Request, seed int64, seedEnd int64, reRun 
 	task.req = req
 
 	if task.req == nil {
+		task.TaskPending = false
 		return 0, fmt.Errorf("request.Request struct is nil")
 	}
 
 	task.req.ReconnectionManager()
 	if _, err := task.req.connectionManager.GetCluster(task.ClusterConfig); err != nil {
+		task.TaskPending = false
 		return 0, err
 	}
 

--- a/task-config.generated.md
+++ b/task-config.generated.md
@@ -4,34 +4,18 @@
 Each task can be executed using REST endpoints. All tasks tags to provide additional
 configuration that is also available on a per-task basis:
 
+ * [/bulk-delete](#bulk-delete)
+ * [/bulk-insert](#bulk-insert)
+ * [/bulk-read](#bulk-read)
+ * [/bulk-upsert](#bulk-upsert)
  * [/clear_data](#clear_data)
- * [/delete](#delete)
  * [/fast-insert](#fast-insert)
- * [/insert](#insert)
- * [/read](#read)
  * [/result](#result)
- * [/upsert](#upsert)
+ * [/single-insert](#single-insert)
  * [/validate](#validate)
 
 ---
-#### /clear_data
-
- REST : POST
-
-Description : The Task clear operation will remove the metadata from the bucket on the specific Couchbase server where
-the test was executed.
-
-| Name | Type | JSON Tag |
-| ---- | ---- | -------- |
-| `IdentifierToken` | `string` | `json:identifierToken`  |
-| `Username` | `string` | `json:username`  |
-| `Password` | `string` | `json:password`  |
-| `Bucket` | `string` | `json:bucket,omitempty`  |
-| `Scope` | `string` | `json:scope,omitempty`  |
-| `Collection` | `string` | `json:collection,omitempty`  |
-
----
-#### /delete
+#### /bulk-delete
 
  REST : POST
 
@@ -49,26 +33,7 @@ The task will delete documents from [start,end] inclusive.
 | `OperationConfig` | `ptr` | `json:operationConfig,omitempty`  |
 
 ---
-#### /fast-insert
-
- REST : Post
-
-Description : Fast Insert task uploads documents in bulk into a bucket without maintaining intermediate state of task 
-During fast operations, An incomplete task will be retied as whole if server dies in between of the operation.
- 
-
-| Name | Type | JSON Tag |
-| ---- | ---- | -------- |
-| `IdentifierToken` | `string` | `json:identifierToken`  |
-| `ClusterConfig` | `ptr` | `json:clusterConfig`  |
-| `Bucket` | `string` | `json:bucket`  |
-| `Scope` | `string` | `json:scope,omitempty`  |
-| `Collection` | `string` | `json:collection,omitempty`  |
-| `InsertOptions` | `ptr` | `json:insertOptions,omitempty`  |
-| `OperationConfig` | `ptr` | `json:operationConfig,omitempty`  |
-
----
-#### /insert
+#### /bulk-insert
 
  REST : POST
 
@@ -90,7 +55,7 @@ The durability while inserting a document can be set using following values in t
 | `OperationConfig` | `ptr` | `json:operationConfig,omitempty`  |
 
 ---
-#### /read
+#### /bulk-read
 
  REST : POST
 
@@ -106,20 +71,7 @@ Description : Read Task get documents from bucket and validate them with the exp
 | `OperationConfig` | `ptr` | `json:operationConfig,omitempty`  |
 
 ---
-#### /result
-
- REST : POST
-
-Description :  Task result is retrieved via this endpoint.
-
-
-| Name | Type | JSON Tag |
-| ---- | ---- | -------- |
-| `Seed` | `string` | `json:seed`  |
-| `DeleteRecord` | `bool` | `json:deleteRecord`  |
-
----
-#### /upsert
+#### /bulk-upsert
 
  REST : POST
 
@@ -136,6 +88,73 @@ We need to share the fields we want to update in a json document using SQL++ syn
 | `Collection` | `string` | `json:collection,omitempty`  |
 | `InsertOptions` | `ptr` | `json:insertOptions,omitempty`  |
 | `OperationConfig` | `ptr` | `json:operationConfig,omitempty`  |
+
+---
+#### /clear_data
+
+ REST : POST
+
+Description : The Task clear operation will remove the metadata from the bucket on the specific Couchbase server where
+the test was executed.
+
+| Name | Type | JSON Tag |
+| ---- | ---- | -------- |
+| `IdentifierToken` | `string` | `json:identifierToken`  |
+| `Username` | `string` | `json:username`  |
+| `Password` | `string` | `json:password`  |
+| `Bucket` | `string` | `json:bucket,omitempty`  |
+| `Scope` | `string` | `json:scope,omitempty`  |
+| `Collection` | `string` | `json:collection,omitempty`  |
+
+---
+#### /fast-insert
+
+ REST : Post
+
+Description : Fast Insert task uploads documents in bulk into a bucket without maintaining intermediate state of task 
+During fast operations, An incomplete task will be retied as whole if server dies in between of the operation.
+ 
+
+| Name | Type | JSON Tag |
+| ---- | ---- | -------- |
+| `IdentifierToken` | `string` | `json:identifierToken`  |
+| `ClusterConfig` | `ptr` | `json:clusterConfig`  |
+| `Bucket` | `string` | `json:bucket`  |
+| `Scope` | `string` | `json:scope,omitempty`  |
+| `Collection` | `string` | `json:collection,omitempty`  |
+| `InsertOptions` | `ptr` | `json:insertOptions,omitempty`  |
+| `OperationConfig` | `ptr` | `json:operationConfig,omitempty`  |
+
+---
+#### /result
+
+ REST : POST
+
+Description :  Task result is retrieved via this endpoint.
+
+
+| Name | Type | JSON Tag |
+| ---- | ---- | -------- |
+| `Seed` | `string` | `json:seed`  |
+| `DeleteRecord` | `bool` | `json:deleteRecord`  |
+
+---
+#### /single-insert
+
+ REST : POST
+
+Description : Single insert task uploads key value in CB.
+
+
+| Name | Type | JSON Tag |
+| ---- | ---- | -------- |
+| `IdentifierToken` | `string` | `json:identifierToken`  |
+| `ClusterConfig` | `ptr` | `json:clusterConfig`  |
+| `Bucket` | `string` | `json:bucket`  |
+| `Scope` | `string` | `json:scope,omitempty`  |
+| `Collection` | `string` | `json:collection,omitempty`  |
+| `InsertOptions` | `ptr` | `json:insertOptions,omitempty`  |
+| `OperationConfig` | `ptr` | `json:singleOperationConfig`  |
 
 ---
 #### /validate
@@ -159,8 +178,10 @@ Description : Validates every document in the cluster's bucket
  * [clusterConfig](#clusterconfig)
  * [compressionConfig](#compressionconfig)
  * [insertOptions](#insertoptions)
+ * [keyValue](#keyvalue)
  * [operationConfig](#operationconfig)
  * [removeOptions](#removeoptions)
+ * [singleOperationConfig](#singleoperationconfig)
  * [timeoutsConfig](#timeoutsconfig)
 
 ---
@@ -189,6 +210,12 @@ Description : Validates every document in the cluster's bucket
 | `ReplicateTo` | `uint` | `json:replicateTo,omitempty`  |
 | `Durability` | `string` | `json:durability,omitempty`  |
 | `Timeout` | `int` | `json:timeout,omitempty`  |
+#### keyValue
+
+| Name | Type | JSON Tag |
+| ---- | ---- | -------- |
+| `Key` | `string` | `json:key`  |
+| `Doc` | `interface` | `json:value`  |
 #### operationConfig
 
 | Name | Type | JSON Tag |
@@ -215,6 +242,12 @@ Description : Validates every document in the cluster's bucket
 | `ReplicateTo` | `uint` | `json:replicateTo,omitempty`  |
 | `Durability` | `string` | `json:durability,omitempty`  |
 | `Timeout` | `int` | `json:timeout,omitempty`  |
+#### singleOperationConfig
+
+| Name | Type | JSON Tag |
+| ---- | ---- | -------- |
+| `KeyValue` | `slice` | `json:keyValue`  |
+| `ReadYourOwnWrite` | `bool` | `json:readYourOwnWrite,omitempty`  |
 #### timeoutsConfig
 
 | Name | Type | JSON Tag |


### PR DESCRIPTION
1. Added task_single_create.go to support key-value create operations.
2. Added SingleOperationConfig as helper struct in helper.go to support single CRUDS.
3. Renamed [insert, upsert, delete, read] with bulk prefix for differentiation.