### PR TITLE
Updates :-

### DIFF
--- a/internal/sdk/cluster_connection_manager.go
+++ b/internal/sdk/cluster_connection_manager.go
@@ -86,6 +86,9 @@ func (cm *ConnectionManager) getClusterObject(clusterConfig *ClusterConfig) (*Cl
 				MinSize:  clusterConfig.CompressionConfig.MinSize,
 				MinRatio: clusterConfig.CompressionConfig.MinRatio,
 			},
+			SecurityConfig: gocb.SecurityConfig{
+				TLSSkipVerify: true,
+			},
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
 # Issue

Document loader gives unambiguous timeout while connecting to cluster due to TLS verification in Dev/SBX environment. 

### Fix

Pass TLS skip verify as true in cluster config so the cluster connection does not fails due to TLS verification






