### PR TITLE
Updates :-

### DIFF
--- a/internal/task_meta_data/doc_meta_deta_manager.go
+++ b/internal/task_meta_data/doc_meta_deta_manager.go
@@ -149,11 +149,12 @@ func NewDocumentsMetaData() *DocumentsMetaData {
 	}
 }
 
-func (m *DocumentsMetaData) GetDocumentsMetadata(docId, template string, docSize int,
+func (m *DocumentsMetaData) GetDocumentsMetadata(collectionIdentifier, docId, template string, docSize int,
 	resetValue bool) *DocumentMetaData {
 	defer m.lock.Unlock()
 	m.lock.Lock()
 	seed := int64(time.Now().UnixNano())
+	docId = docId + " " + collectionIdentifier
 	_, ok := m.MetaData[docId]
 	if docSize == 0 {
 		docSize = docgenerator.DefaultDocSize
@@ -182,6 +183,7 @@ func (m *DocumentsMetaData) GetDocumentsMetadata(docId, template string, docSize
 	return m.MetaData[docId]
 }
 
-func (m *DocumentsMetaData) RemoveDocument(key string) {
-	delete(m.MetaData, key)
+func (m *DocumentsMetaData) RemoveDocument(collectionIdentifier, docId string) {
+	docId = docId + " " + collectionIdentifier
+	delete(m.MetaData, docId)
 }

--- a/internal/tasks/task_single_create.go
+++ b/internal/tasks/task_single_create.go
@@ -137,7 +137,8 @@ func singleInsertDocuments(task *SingleInsertTask, collectionObject *sdk.Collect
 		group.Go(func() error {
 			key := <-dataChannel
 
-			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, task.SingleOperationConfig.Template,
+			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key,
+				task.SingleOperationConfig.Template,
 				task.SingleOperationConfig.DocSize, false)
 
 			fake := faker.NewWithSeed(rand.NewSource(int64(documentMetaData.Seed)))

--- a/internal/tasks/task_single_delete.go
+++ b/internal/tasks/task_single_delete.go
@@ -133,7 +133,7 @@ func singleDeleteDocuments(task *SingleDeleteTask, collectionObject *sdk.Collect
 		group.Go(func() error {
 			key := <-dataChannel
 
-			task.req.documentsMeta.RemoveDocument(key)
+			task.req.documentsMeta.RemoveDocument(task.CollectionIdentifier(), key)
 
 			r, err := collectionObject.Collection.Remove(key, &gocb.RemoveOptions{
 				Cas:             gocb.Cas(task.RemoveOptions.Cas),

--- a/internal/tasks/task_single_read.go
+++ b/internal/tasks/task_single_read.go
@@ -125,7 +125,7 @@ func singleReadDocuments(task *SingleReadTask, collectionObject *sdk.CollectionO
 
 		group.Go(func() error {
 			key := <-dataChannel
-			task.req.documentsMeta.GetDocumentsMetadata(key, task.SingleOperationConfig.Template,
+			task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, task.SingleOperationConfig.Template,
 				task.SingleOperationConfig.DocSize, false)
 
 			result, err := collectionObject.Collection.Get(key, nil)

--- a/internal/tasks/task_single_replace.go
+++ b/internal/tasks/task_single_replace.go
@@ -137,7 +137,7 @@ func singleReplaceDocuments(task *SingleReplaceTask, collectionObject *sdk.Colle
 		group.Go(func() error {
 			key := <-dataChannel
 
-			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, task.SingleOperationConfig.Template,
+			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, task.SingleOperationConfig.Template,
 				task.SingleOperationConfig.DocSize, true)
 
 			fake := faker.NewWithSeed(rand.NewSource(int64(documentMetaData.Seed)))

--- a/internal/tasks/task_single_sub_doc_delete.go
+++ b/internal/tasks/task_single_sub_doc_delete.go
@@ -129,7 +129,7 @@ func singleDeleteSubDocuments(task *SingleSubDocDelete, collectionObject *sdk.Co
 
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
-	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, "", 0, false)
+	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)
 
 	for _, path := range task.SingleSubDocOperationConfig.Paths {
 		_ = documentMetaData.SubDocument(path, task.RemoveSpecOptions.IsXattr, task.SingleSubDocOperationConfig.DocSize,

--- a/internal/tasks/task_single_sub_doc_insert.go
+++ b/internal/tasks/task_single_sub_doc_insert.go
@@ -131,7 +131,7 @@ func singleInsertSubDocuments(task *SingleSubDocInsert, collectionObject *sdk.Co
 
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
-	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, "", 0, false)
+	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)
 
 	for _, path := range task.SingleSubDocOperationConfig.Paths {
 		subDocument := documentMetaData.SubDocument(path, task.InsertSpecOptions.IsXattr,

--- a/internal/tasks/task_single_sub_doc_read.go
+++ b/internal/tasks/task_single_sub_doc_read.go
@@ -125,7 +125,7 @@ func (task *SingleSubDocRead) Do() error {
 func singleReadSubDocuments(task *SingleSubDocRead, collectionObject *sdk.CollectionObject) {
 	var iOps []gocb.LookupInSpec
 	key := task.SingleSubDocOperationConfig.Key
-	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, "", 0, false)
+	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)
 
 	for _, path := range task.SingleSubDocOperationConfig.Paths {
 

--- a/internal/tasks/task_single_sub_doc_replace.go
+++ b/internal/tasks/task_single_sub_doc_replace.go
@@ -127,7 +127,7 @@ func (task *SingleSubDocReplace) Do() error {
 func singleReplaceSubDocuments(task *SingleSubDocReplace, collectionObject *sdk.CollectionObject) {
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
-	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, "", 0, false)
+	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)
 
 	for _, path := range task.SingleSubDocOperationConfig.Paths {
 		subDocument := documentMetaData.SubDocument(path, task.ReplaceSpecOptions.IsXattr, task.SingleSubDocOperationConfig.

--- a/internal/tasks/task_single_sub_doc_upsert.go
+++ b/internal/tasks/task_single_sub_doc_upsert.go
@@ -131,7 +131,7 @@ func singleUpsertSubDocuments(task *SingleSubDocUpsert, collectionObject *sdk.Co
 
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
-	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, "", 0, false)
+	documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)
 
 	for _, path := range task.SingleSubDocOperationConfig.Paths {
 		subDocument := documentMetaData.SubDocument(path, task.InsertSpecOptions.IsXattr,

--- a/internal/tasks/task_single_touch.go
+++ b/internal/tasks/task_single_touch.go
@@ -134,7 +134,7 @@ func singleTouchDocuments(task *SingleTouchTask, collectionObject *sdk.Collectio
 		group.Go(func() error {
 			key := <-dataChannel
 
-			task.req.documentsMeta.GetDocumentsMetadata(key, task.SingleOperationConfig.Template,
+			task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, task.SingleOperationConfig.Template,
 				task.SingleOperationConfig.DocSize, false)
 
 			result, err := collectionObject.Collection.Touch(key, time.Duration(task.InsertOptions.Timeout)*time.Second,

--- a/internal/tasks/task_single_upsert.go
+++ b/internal/tasks/task_single_upsert.go
@@ -136,7 +136,7 @@ func singleUpsertDocuments(task *SingleUpsertTask, collectionObject *sdk.Collect
 		group.Go(func() error {
 			key := <-dataChannel
 
-			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, task.SingleOperationConfig.Template,
+			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, task.SingleOperationConfig.Template,
 				task.SingleOperationConfig.DocSize, false)
 
 			fake := faker.NewWithSeed(rand.NewSource(int64(documentMetaData.Seed)))

--- a/internal/tasks/task_single_validate.go
+++ b/internal/tasks/task_single_validate.go
@@ -121,7 +121,7 @@ func validateSingleDocuments(task *SingleValidate, collectionObject *sdk.Collect
 		group.Go(func() error {
 			key := <-dataChannel
 
-			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(key, task.SingleOperationConfig.Template,
+			documentMetaData := task.req.documentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, task.SingleOperationConfig.Template,
 				task.SingleOperationConfig.DocSize, false)
 
 			fake := faker.NewWithSeed(rand.NewSource(int64(documentMetaData.Seed)))


### PR DESCRIPTION
1. Added unique parameter to identify the doc's meta-data associated to particular CB server's collection in a test run.