### PR TITLE
Updates :-

### DIFF
--- a/internal/task_state/task_state.go
+++ b/internal/task_state/task_state.go
@@ -14,7 +14,7 @@ import (
 const (
 	COMPLETED         = 1
 	ERR               = 0
-	StateChannelLimit = 100000
+	StateChannelLimit = 10000
 	TASKSTATELOGS     = "./internal/task_state/task_state_logs"
 )
 
@@ -120,7 +120,7 @@ func (t *TaskState) StoreState() {
 	go func() {
 		var completed []int64
 		var err []int64
-		d := time.NewTicker(30 * time.Second)
+		d := time.NewTicker(10 * time.Second)
 		defer d.Stop()
 		if t.ctx.Err() != nil {
 			log.Print("Ctx closed for StoreState()")

--- a/internal/tasks/task_bulk_delete.go
+++ b/internal/tasks/task_bulk_delete.go
@@ -122,6 +122,7 @@ func (task *DeleteTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_bulk_insert.go
+++ b/internal/tasks/task_bulk_insert.go
@@ -134,6 +134,7 @@ func (task *InsertTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_bulk_read.go
+++ b/internal/tasks/task_bulk_read.go
@@ -57,6 +57,7 @@ func (task *ReadTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_bulk_touch.go
+++ b/internal/tasks/task_bulk_touch.go
@@ -125,6 +125,7 @@ func (task *TouchTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_bulk_upsert.go
+++ b/internal/tasks/task_bulk_upsert.go
@@ -126,6 +126,7 @@ func (task *UpsertTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_run_query.go
+++ b/internal/tasks/task_run_query.go
@@ -96,6 +96,7 @@ func (task *QueryTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()
 }

--- a/internal/tasks/task_single_create.go
+++ b/internal/tasks/task_single_create.go
@@ -100,6 +100,7 @@ func (task *SingleInsertTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_delete.go
+++ b/internal/tasks/task_single_delete.go
@@ -96,6 +96,7 @@ func (task *SingleDeleteTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_replace.go
+++ b/internal/tasks/task_single_replace.go
@@ -99,6 +99,7 @@ func (task *SingleReplaceTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_delete.go
+++ b/internal/tasks/task_single_sub_doc_delete.go
@@ -102,6 +102,7 @@ func (task *SingleSubDocDelete) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_insert.go
+++ b/internal/tasks/task_single_sub_doc_insert.go
@@ -104,6 +104,7 @@ func (task *SingleSubDocInsert) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_read.go
+++ b/internal/tasks/task_single_sub_doc_read.go
@@ -100,6 +100,7 @@ func (task *SingleSubDocRead) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_replace.go
+++ b/internal/tasks/task_single_sub_doc_replace.go
@@ -102,6 +102,8 @@ func (task *SingleSubDocReplace) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
+	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()
 }

--- a/internal/tasks/task_single_sub_doc_upsert.go
+++ b/internal/tasks/task_single_sub_doc_upsert.go
@@ -104,6 +104,7 @@ func (task *SingleSubDocUpsert) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_touch.go
+++ b/internal/tasks/task_single_touch.go
@@ -96,6 +96,7 @@ func (task *SingleTouchTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_upsert.go
+++ b/internal/tasks/task_single_upsert.go
@@ -99,6 +99,7 @@ func (task *SingleUpsertTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_validate.go
+++ b/internal/tasks/task_single_validate.go
@@ -37,6 +37,7 @@ func (task *SingleValidate) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_sub_doc_delete.go
+++ b/internal/tasks/task_sub_doc_delete.go
@@ -130,6 +130,7 @@ func (task *SubDocDelete) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_sub_doc_insert.go
+++ b/internal/tasks/task_sub_doc_insert.go
@@ -134,6 +134,7 @@ func (task *SubDocInsert) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_sub_doc_read.go
+++ b/internal/tasks/task_sub_doc_read.go
@@ -120,6 +120,7 @@ func (task *SubDocRead) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_sub_doc_replace.go
+++ b/internal/tasks/task_sub_doc_replace.go
@@ -130,6 +130,7 @@ func (task *SubDocReplace) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_sub_doc_upsert.go
+++ b/internal/tasks/task_sub_doc_upsert.go
@@ -133,6 +133,7 @@ func (task *SubDocUpsert) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false

--- a/internal/tasks/task_validate.go
+++ b/internal/tasks/task_validate.go
@@ -61,6 +61,7 @@ func (task *ValidateTask) tearUp() error {
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
+	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false


### PR DESCRIPTION
Refactor: Implement lock-free Result package for storing results

Restructured the Result package to enable lock-free operations. The new mechanism for storing results mirrors the approach used for task state storage, involving periodic writes after a set time interval ("x"). This replaces the previous strategy of locking the structure for every success or failure occurrence.