### PR TITLE
Updates :-

### DIFF
--- a/internal/server_requests/server_requests.go
+++ b/internal/server_requests/server_requests.go
@@ -31,6 +31,7 @@ func NewServerRequests() *ServerRequests {
 		for identifier, _ := range sr.Identifiers {
 			r, err := tasks.ReadRequestFromFile(identifier)
 			if r != nil && err == nil {
+				r.InitializeContext()
 				_ = sr.add(identifier, r, false)
 				for i := range r.Tasks {
 					t := r.Tasks[i]
@@ -212,6 +213,7 @@ func (sr *ServerRequests) ClearIdentifierAndRequest(identifier string) error {
 		r, _ := sr.RequestLookup.Load(identifier)
 		req, ok := r.(*tasks.Request)
 		if ok && req != nil {
+			req.Cancel()
 			req.DisconnectConnectionManager()
 			req.ClearAllTask()
 		}

--- a/internal/tasks/task_retry_exceptions.go
+++ b/internal/tasks/task_retry_exceptions.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 	"github.com/couchbaselabs/sirius/internal/sdk"
 	"github.com/couchbaselabs/sirius/internal/task_errors"
@@ -22,6 +23,10 @@ func (r *RetryExceptions) Describe() string {
 }
 
 func (r *RetryExceptions) Do() error {
+	if r.req.ContextClosed() {
+		return errors.New("req is cleared")
+	}
+
 	c, e := r.Task.GetCollectionObject()
 	if e != nil {
 		r.Task.tearUp()

--- a/internal/tasks/task_run_query.go
+++ b/internal/tasks/task_run_query.go
@@ -225,6 +225,11 @@ func buildIndexViaN1QL(task *QueryTask, cluster *gocb.Cluster, scope *gocb.Scope
 
 // runN1qlQuery runs query over a duration of time
 func runN1qlQuery(task *QueryTask, cluster *gocb.Cluster, scope *gocb.Scope, collection *gocb.Collection) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	group := errgroup.Group{}
 	queries, err := task.gen.Template.GenerateQueries(task.Bucket, scope.Name(), collection.Name())

--- a/internal/tasks/task_single_create.go
+++ b/internal/tasks/task_single_create.go
@@ -127,12 +127,23 @@ func (task *SingleInsertTask) Do() error {
 // singleInsertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleInsertDocuments(task *SingleInsertTask, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_single_read.go
+++ b/internal/tasks/task_single_read.go
@@ -115,12 +115,23 @@ func (task *SingleReadTask) Do() error {
 // singleDeleteDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleReadDocuments(task *SingleReadTask, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_single_sub_doc_delete.go
+++ b/internal/tasks/task_single_sub_doc_delete.go
@@ -129,6 +129,10 @@ func (task *SingleSubDocDelete) Do() error {
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleDeleteSubDocuments(task *SingleSubDocDelete, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_insert.go
+++ b/internal/tasks/task_single_sub_doc_insert.go
@@ -131,6 +131,10 @@ func (task *SingleSubDocInsert) Do() error {
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleInsertSubDocuments(task *SingleSubDocInsert, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_read.go
+++ b/internal/tasks/task_single_sub_doc_read.go
@@ -125,6 +125,11 @@ func (task *SingleSubDocRead) Do() error {
 
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleReadSubDocuments(task *SingleSubDocRead, collectionObject *sdk.CollectionObject) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.LookupInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_replace.go
+++ b/internal/tasks/task_single_sub_doc_replace.go
@@ -128,6 +128,11 @@ func (task *SingleSubDocReplace) Do() error {
 
 // singleReplaceSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleReplaceSubDocuments(task *SingleSubDocReplace, collectionObject *sdk.CollectionObject) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_upsert.go
+++ b/internal/tasks/task_single_sub_doc_upsert.go
@@ -131,6 +131,10 @@ func (task *SingleSubDocUpsert) Do() error {
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleUpsertSubDocuments(task *SingleSubDocUpsert, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_upsert.go
+++ b/internal/tasks/task_single_upsert.go
@@ -126,12 +126,23 @@ func (task *SingleUpsertTask) Do() error {
 // singleUpsertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleUpsertDocuments(task *SingleUpsertTask, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_single_validate.go
+++ b/internal/tasks/task_single_validate.go
@@ -111,12 +111,24 @@ func (task *SingleValidate) Do() error {
 
 // validateSingleDocuments validates the document integrity as per meta-data stored in Sirius
 func validateSingleDocuments(task *SingleValidate, collectionObject *sdk.CollectionObject) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_sub_doc_insert.go
+++ b/internal/tasks/task_sub_doc_insert.go
@@ -167,6 +167,10 @@ func (task *SubDocInsert) Do() error {
 // insertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func insertSubDocuments(task *SubDocInsert, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan int64, MaxConcurrentRoutines)
 
@@ -179,6 +183,12 @@ func insertSubDocuments(task *SubDocInsert, collectionObject *sdk.CollectionObje
 	}
 	group := errgroup.Group{}
 	for iteration := task.SubDocOperationConfig.Start; iteration < task.SubDocOperationConfig.End; iteration++ {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
@@ -257,6 +267,11 @@ func insertSubDocuments(task *SubDocInsert, collectionObject *sdk.CollectionObje
 }
 
 func (task *SubDocInsert) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
+
+	if task.SubDocOperationConfig.Exceptions.RetryAttempts <= 0 {
+		return
+	}
+
 	task.State.StopStoringState()
 
 	// Get all the errorOffset
@@ -363,6 +378,7 @@ func (task *SubDocInsert) PostTaskExceptionHandling(collectionObject *sdk.Collec
 	task.State.MakeCompleteKeyFromMap(completedOffsetMaps)
 	task.State.MakeErrorKeyFromMap(errorOffsetMaps)
 	task.Result.Failure = int64(len(task.State.KeyStates.Err))
+	log.Println("completed retrying:- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
 
 }
 


### PR DESCRIPTION
Refactor: Implement mechanism to stop running tasks.

Create a system to interrupt ongoing Sirius tasks by closing a global channel tied to a specific test's global identifier. This mechanism involves closing the global channel upon receiving a clear resources request, signaling the associated Go routine to cease any ongoing operations.
