### PR TITLE
Fixed task result mechansim and stop rounties for cancelled tasks

### DIFF
--- a/internal/server_requests/server_requests.go
+++ b/internal/server_requests/server_requests.go
@@ -31,6 +31,7 @@ func NewServerRequests() *ServerRequests {
 		for identifier, _ := range sr.Identifiers {
 			r, err := tasks.ReadRequestFromFile(identifier)
 			if r != nil && err == nil {
+				r.InitializeContext()
 				_ = sr.add(identifier, r, false)
 				for i := range r.Tasks {
 					t := r.Tasks[i]
@@ -212,6 +213,7 @@ func (sr *ServerRequests) ClearIdentifierAndRequest(identifier string) error {
 		r, _ := sr.RequestLookup.Load(identifier)
 		req, ok := r.(*tasks.Request)
 		if ok && req != nil {
+			req.Cancel()
 			req.DisconnectConnectionManager()
 			req.ClearAllTask()
 		}

--- a/internal/task_result/task_result.go
+++ b/internal/task_result/task_result.go
@@ -293,6 +293,9 @@ func (t *TaskResult) StoreResultList(resultList []ResultHelper) {
 }
 
 func (t *TaskResult) StopStoringResult() {
+	if t.ctx.Err() != nil {
+		return
+	}
 	time.Sleep(1 * time.Second)
 	t.cancel()
 	time.Sleep(1 * time.Second)

--- a/internal/task_state/task_state.go
+++ b/internal/task_state/task_state.go
@@ -180,7 +180,9 @@ func (t *TaskState) StoreError(err []int64) {
 // StopStoringState will terminate the thread which is receiving offset
 // on dataChannel.
 func (t *TaskState) StopStoringState() {
-	time.Sleep(1 * time.Second)
+	if t.ctx.Err() != nil {
+		return
+	}
 	t.cancel()
 	time.Sleep(1 * time.Second)
 }

--- a/internal/tasks/task_bulk_insert.go
+++ b/internal/tasks/task_bulk_insert.go
@@ -130,11 +130,10 @@ func (task *InsertTask) tearUp() error {
 	//if err := task.State.SaveTaskSateOnDisk(); err != nil {
 	//	log.Println("Error in storing TASK State on DISK")
 	//}
-
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false
@@ -192,7 +191,6 @@ func insertDocuments(task *InsertTask, collectionObject *sdk.CollectionObject) {
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
-
 		group.Go(func() error {
 			offset := <-dataChannel
 			key := offset + task.MetaData.Seed
@@ -254,6 +252,7 @@ func insertDocuments(task *InsertTask, collectionObject *sdk.CollectionObject) {
 }
 
 func (task *InsertTask) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
+	task.Result.StopStoringResult()
 	task.State.StopStoringState()
 
 	if task.OperationConfig.Exceptions.RetryAttempts <= 0 {

--- a/internal/tasks/task_bulk_read.go
+++ b/internal/tasks/task_bulk_read.go
@@ -54,10 +54,10 @@ func (task *ReadTask) CheckIfPending() bool {
 }
 
 func (task *ReadTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false
@@ -210,11 +210,11 @@ func getDocuments(task *ReadTask, collectionObject *sdk.CollectionObject) {
 }
 
 func (task *ReadTask) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 	if task.OperationConfig.Exceptions.RetryAttempts <= 0 {
 		return
 	}
-
-	task.State.StopStoringState()
 
 	// Get all the errorOffset
 	errorOffsetMaps := task.State.ReturnErrOffset()

--- a/internal/tasks/task_bulk_touch.go
+++ b/internal/tasks/task_bulk_touch.go
@@ -122,6 +122,7 @@ func (task *TouchTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *TouchTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
@@ -183,7 +184,6 @@ func touchDocuments(task *TouchTask, collectionObject *sdk.CollectionObject) {
 
 		routineLimiter <- struct{}{}
 		dataChannel <- i
-
 		group.Go(func() error {
 			var err error
 			offset := <-dataChannel
@@ -230,12 +230,11 @@ func touchDocuments(task *TouchTask, collectionObject *sdk.CollectionObject) {
 }
 
 func (task *TouchTask) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
-
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 	if task.OperationConfig.Exceptions.RetryAttempts <= 0 {
 		return
 	}
-
-	task.State.StopStoringState()
 
 	// Get all the errorOffset
 	errorOffsetMaps := task.State.ReturnErrOffset()

--- a/internal/tasks/task_retry_exceptions.go
+++ b/internal/tasks/task_retry_exceptions.go
@@ -1,6 +1,7 @@
 package tasks
 
 import (
+	"errors"
 	"fmt"
 	"github.com/couchbaselabs/sirius/internal/sdk"
 	"github.com/couchbaselabs/sirius/internal/task_errors"
@@ -22,6 +23,10 @@ func (r *RetryExceptions) Describe() string {
 }
 
 func (r *RetryExceptions) Do() error {
+	if r.req.ContextClosed() {
+		return errors.New("req is cleared")
+	}
+
 	c, e := r.Task.GetCollectionObject()
 	if e != nil {
 		r.Task.tearUp()

--- a/internal/tasks/task_run_query.go
+++ b/internal/tasks/task_run_query.go
@@ -225,6 +225,11 @@ func buildIndexViaN1QL(task *QueryTask, cluster *gocb.Cluster, scope *gocb.Scope
 
 // runN1qlQuery runs query over a duration of time
 func runN1qlQuery(task *QueryTask, cluster *gocb.Cluster, scope *gocb.Scope, collection *gocb.Collection) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	group := errgroup.Group{}
 	queries, err := task.gen.Template.GenerateQueries(task.Bucket, scope.Name(), collection.Name())

--- a/internal/tasks/task_run_query.go
+++ b/internal/tasks/task_run_query.go
@@ -93,10 +93,10 @@ func (task *QueryTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *QueryTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()
 }
@@ -140,9 +140,6 @@ func (task *QueryTask) Do() error {
 
 	runN1qlQuery(task, cluster, s, c.Collection)
 
-	if err := task.Result.SaveResultIntoFile(); err != nil {
-		log.Println("not able to save Result into ", task.ResultSeed)
-	}
 	return task.tearUp()
 }
 
@@ -261,7 +258,7 @@ func runN1qlQuery(task *QueryTask, cluster *gocb.Cluster, scope *gocb.Scope, col
 }
 
 func (task *QueryTask) PostTaskExceptionHandling(_ *sdk.CollectionObject) {
-	//TODO implement me
+	task.Result.StopStoringResult()
 }
 
 func (task *QueryTask) MatchResultSeed(resultSeed string) bool {

--- a/internal/tasks/task_single_create.go
+++ b/internal/tasks/task_single_create.go
@@ -97,10 +97,10 @@ func (task *SingleInsertTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *SingleInsertTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_create.go
+++ b/internal/tasks/task_single_create.go
@@ -127,12 +127,23 @@ func (task *SingleInsertTask) Do() error {
 // singleInsertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleInsertDocuments(task *SingleInsertTask, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_single_delete.go
+++ b/internal/tasks/task_single_delete.go
@@ -93,10 +93,10 @@ func (task *SingleDeleteTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *SingleDeleteTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_read.go
+++ b/internal/tasks/task_single_read.go
@@ -86,6 +86,7 @@ func (task *SingleReadTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *SingleReadTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}

--- a/internal/tasks/task_single_read.go
+++ b/internal/tasks/task_single_read.go
@@ -115,12 +115,23 @@ func (task *SingleReadTask) Do() error {
 // singleDeleteDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleReadDocuments(task *SingleReadTask, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_single_replace.go
+++ b/internal/tasks/task_single_replace.go
@@ -96,10 +96,10 @@ func (task *SingleReplaceTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *SingleReplaceTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_delete.go
+++ b/internal/tasks/task_single_sub_doc_delete.go
@@ -99,10 +99,10 @@ func (task *SingleSubDocDelete) Config(req *Request, reRun bool) (int64, error) 
 }
 
 func (task *SingleSubDocDelete) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_delete.go
+++ b/internal/tasks/task_single_sub_doc_delete.go
@@ -129,6 +129,10 @@ func (task *SingleSubDocDelete) Do() error {
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleDeleteSubDocuments(task *SingleSubDocDelete, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_insert.go
+++ b/internal/tasks/task_single_sub_doc_insert.go
@@ -101,10 +101,10 @@ func (task *SingleSubDocInsert) Config(req *Request, reRun bool) (int64, error) 
 }
 
 func (task *SingleSubDocInsert) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_insert.go
+++ b/internal/tasks/task_single_sub_doc_insert.go
@@ -131,6 +131,10 @@ func (task *SingleSubDocInsert) Do() error {
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleInsertSubDocuments(task *SingleSubDocInsert, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_read.go
+++ b/internal/tasks/task_single_sub_doc_read.go
@@ -167,7 +167,6 @@ func singleReadSubDocuments(task *SingleSubDocRead, collectionObject *sdk.Collec
 		}
 	}
 
-	task.PostTaskExceptionHandling(collectionObject)
 	log.Println("completed :- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
 }
 

--- a/internal/tasks/task_single_sub_doc_read.go
+++ b/internal/tasks/task_single_sub_doc_read.go
@@ -125,6 +125,11 @@ func (task *SingleSubDocRead) Do() error {
 
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleReadSubDocuments(task *SingleSubDocRead, collectionObject *sdk.CollectionObject) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.LookupInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_replace.go
+++ b/internal/tasks/task_single_sub_doc_replace.go
@@ -99,10 +99,10 @@ func (task *SingleSubDocReplace) Config(req *Request, reRun bool) (int64, error)
 }
 
 func (task *SingleSubDocReplace) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_replace.go
+++ b/internal/tasks/task_single_sub_doc_replace.go
@@ -128,6 +128,11 @@ func (task *SingleSubDocReplace) Do() error {
 
 // singleReplaceSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleReplaceSubDocuments(task *SingleSubDocReplace, collectionObject *sdk.CollectionObject) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_sub_doc_upsert.go
+++ b/internal/tasks/task_single_sub_doc_upsert.go
@@ -101,10 +101,10 @@ func (task *SingleSubDocUpsert) Config(req *Request, reRun bool) (int64, error) 
 }
 
 func (task *SingleSubDocUpsert) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_sub_doc_upsert.go
+++ b/internal/tasks/task_single_sub_doc_upsert.go
@@ -131,6 +131,10 @@ func (task *SingleSubDocUpsert) Do() error {
 // singleInsertSubDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleUpsertSubDocuments(task *SingleSubDocUpsert, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	var iOps []gocb.MutateInSpec
 	key := task.SingleSubDocOperationConfig.Key
 	documentMetaData := task.req.DocumentsMeta.GetDocumentsMetadata(task.CollectionIdentifier(), key, "", 0, false)

--- a/internal/tasks/task_single_touch.go
+++ b/internal/tasks/task_single_touch.go
@@ -93,10 +93,10 @@ func (task *SingleTouchTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *SingleTouchTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_upsert.go
+++ b/internal/tasks/task_single_upsert.go
@@ -126,12 +126,23 @@ func (task *SingleUpsertTask) Do() error {
 // singleUpsertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func singleUpsertDocuments(task *SingleUpsertTask, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_single_upsert.go
+++ b/internal/tasks/task_single_upsert.go
@@ -96,10 +96,10 @@ func (task *SingleUpsertTask) Config(req *Request, reRun bool) (int64, error) {
 }
 
 func (task *SingleUpsertTask) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_validate.go
+++ b/internal/tasks/task_single_validate.go
@@ -34,10 +34,10 @@ func (task *SingleValidate) Describe() string {
 }
 
 func (task *SingleValidate) tearUp() error {
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()

--- a/internal/tasks/task_single_validate.go
+++ b/internal/tasks/task_single_validate.go
@@ -111,12 +111,24 @@ func (task *SingleValidate) Do() error {
 
 // validateSingleDocuments validates the document integrity as per meta-data stored in Sirius
 func validateSingleDocuments(task *SingleValidate, collectionObject *sdk.CollectionObject) {
+
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan string, MaxConcurrentRoutines)
 
 	group := errgroup.Group{}
 
 	for _, data := range task.SingleOperationConfig.Keys {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
+
 		routineLimiter <- struct{}{}
 		dataChannel <- data
 

--- a/internal/tasks/task_sub_doc_delete.go
+++ b/internal/tasks/task_sub_doc_delete.go
@@ -127,10 +127,10 @@ func (task *SubDocDelete) tearUp() error {
 	//if err := task.State.SaveTaskSateOnDisk(); err != nil {
 	//	log.Println("Error in storing TASK State on DISK")
 	//}
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false
@@ -188,7 +188,6 @@ func deleteSubDocuments(task *SubDocDelete, collectionObject *sdk.CollectionObje
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
-
 		group.Go(func() error {
 			offset := <-dataChannel
 			key := offset + task.MetaData.Seed
@@ -258,12 +257,11 @@ func deleteSubDocuments(task *SubDocDelete, collectionObject *sdk.CollectionObje
 }
 
 func (task *SubDocDelete) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
-
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 	if task.SubDocOperationConfig.Exceptions.RetryAttempts <= 0 {
 		return
 	}
-
-	task.State.StopStoringState()
 
 	// Get all the errorOffset
 	errorOffsetMaps := task.State.ReturnErrOffset()

--- a/internal/tasks/task_sub_doc_insert.go
+++ b/internal/tasks/task_sub_doc_insert.go
@@ -167,6 +167,10 @@ func (task *SubDocInsert) Do() error {
 // insertDocuments uploads new documents in a bucket.scope.collection in a defined batch size at multiple iterations.
 func insertSubDocuments(task *SubDocInsert, collectionObject *sdk.CollectionObject) {
 
+	if task.req.ContextClosed() {
+		return
+	}
+
 	routineLimiter := make(chan struct{}, MaxConcurrentRoutines)
 	dataChannel := make(chan int64, MaxConcurrentRoutines)
 
@@ -179,6 +183,12 @@ func insertSubDocuments(task *SubDocInsert, collectionObject *sdk.CollectionObje
 	}
 	group := errgroup.Group{}
 	for iteration := task.SubDocOperationConfig.Start; iteration < task.SubDocOperationConfig.End; iteration++ {
+
+		if task.req.ContextClosed() {
+			close(routineLimiter)
+			close(dataChannel)
+			return
+		}
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
@@ -257,6 +267,11 @@ func insertSubDocuments(task *SubDocInsert, collectionObject *sdk.CollectionObje
 }
 
 func (task *SubDocInsert) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
+
+	if task.SubDocOperationConfig.Exceptions.RetryAttempts <= 0 {
+		return
+	}
+
 	task.State.StopStoringState()
 
 	// Get all the errorOffset
@@ -363,6 +378,7 @@ func (task *SubDocInsert) PostTaskExceptionHandling(collectionObject *sdk.Collec
 	task.State.MakeCompleteKeyFromMap(completedOffsetMaps)
 	task.State.MakeErrorKeyFromMap(errorOffsetMaps)
 	task.Result.Failure = int64(len(task.State.KeyStates.Err))
+	log.Println("completed retrying:- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
 
 }
 

--- a/internal/tasks/task_sub_doc_read.go
+++ b/internal/tasks/task_sub_doc_read.go
@@ -117,12 +117,11 @@ func (task *SubDocRead) tearUp() error {
 	//if err := task.State.SaveTaskSateOnDisk(); err != nil {
 	//	log.Println("Error in storing TASK State on DISK")
 	//}
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
-	task.State.StopStoringState()
 	task.TaskPending = false
 	return task.req.SaveRequestIntoFile()
 }
@@ -178,7 +177,6 @@ func readSubDocuments(task *SubDocRead, collectionObject *sdk.CollectionObject) 
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
-
 		group.Go(func() error {
 			offset := <-dataChannel
 			key := offset + task.MetaData.Seed
@@ -246,12 +244,12 @@ func readSubDocuments(task *SubDocRead, collectionObject *sdk.CollectionObject) 
 }
 
 func (task *SubDocRead) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 
 	if task.SubDocOperationConfig.Exceptions.RetryAttempts <= 0 {
 		return
 	}
-
-	task.State.StopStoringState()
 
 	// Get all the errorOffset
 	errorOffsetMaps := task.State.ReturnErrOffset()

--- a/internal/tasks/task_sub_doc_replace.go
+++ b/internal/tasks/task_sub_doc_replace.go
@@ -127,10 +127,10 @@ func (task *SubDocReplace) tearUp() error {
 	//if err := task.State.SaveTaskSateOnDisk(); err != nil {
 	//	log.Println("Error in storing TASK State on DISK")
 	//}
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false
@@ -188,7 +188,6 @@ func replaceSubDocuments(task *SubDocReplace, collectionObject *sdk.CollectionOb
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
-
 		group.Go(func() error {
 			offset := <-dataChannel
 			key := offset + task.MetaData.Seed
@@ -261,12 +260,11 @@ func replaceSubDocuments(task *SubDocReplace, collectionObject *sdk.CollectionOb
 }
 
 func (task *SubDocReplace) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
-
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 	if task.SubDocOperationConfig.Exceptions.RetryAttempts <= 0 {
 		return
 	}
-
-	task.State.StopStoringState()
 
 	// Get all the errorOffset
 	errorOffsetMaps := task.State.ReturnErrOffset()

--- a/internal/tasks/task_sub_doc_upsert.go
+++ b/internal/tasks/task_sub_doc_upsert.go
@@ -130,10 +130,10 @@ func (task *SubDocUpsert) tearUp() error {
 	//if err := task.State.SaveTaskSateOnDisk(); err != nil {
 	//	log.Println("Error in storing TASK State on DISK")
 	//}
+	task.Result.StopStoringResult()
 	if err := task.Result.SaveResultIntoFile(); err != nil {
 		log.Println("not able to save Result into ", task.ResultSeed, task.Operation)
 	}
-	task.Result.StopStoringResult()
 	task.Result = nil
 	task.State.StopStoringState()
 	task.TaskPending = false
@@ -191,7 +191,6 @@ func upsertSubDocuments(task *SubDocUpsert, collectionObject *sdk.CollectionObje
 
 		routineLimiter <- struct{}{}
 		dataChannel <- iteration
-
 		group.Go(func() error {
 			offset := <-dataChannel
 			key := offset + task.MetaData.Seed
@@ -265,12 +264,12 @@ func upsertSubDocuments(task *SubDocUpsert, collectionObject *sdk.CollectionObje
 }
 
 func (task *SubDocUpsert) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 
 	if task.SubDocOperationConfig.Exceptions.RetryAttempts <= 0 {
 		return
 	}
-
-	task.State.StopStoringState()
 
 	// Get all the errorOffset
 	errorOffsetMaps := task.State.ReturnErrOffset()

--- a/internal/tasks/task_validate.go
+++ b/internal/tasks/task_validate.go
@@ -297,16 +297,14 @@ func validateDocuments(task *ValidateTask, collectionObject *sdk.CollectionObjec
 	_ = group.Wait()
 	close(routineLimiter)
 	close(dataChannel)
+	task.PostTaskExceptionHandling(collectionObject)
 	log.Println("completed :- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
+
 }
 
 func (task *ValidateTask) PostTaskExceptionHandling(collectionObject *sdk.CollectionObject) {
-	if task.OperationConfig.Exceptions.RetryAttempts <= 0 {
-		return
-	}
-
-	_ = task.Do()
-	log.Println("completed retrying:- ", task.Operation, task.BuildIdentifier(), task.ResultSeed)
+	task.Result.StopStoringResult()
+	task.State.StopStoringState()
 }
 
 func (task *ValidateTask) MatchResultSeed(resultSeed string) bool {

--- a/internal/template/template_hotel.go
+++ b/internal/template/template_hotel.go
@@ -182,11 +182,8 @@ func (h *Hotel) GenerateIndexesForSdk() (map[string][]string, error) {
 
 func (h *Hotel) GenerateSubPathAndValue(fake *faker.Faker) map[string]any {
 	return map[string]interface{}{
-		"fullName":                fake.Person().FirstName() + " " + fake.Person().LastName(),
-		"sex":                     fake.Person().Gender(),
-		"contact.Phone":           fake.Person().Contact().Phone,
-		"contact.email":           fake.Person().Contact().Email,
-		"attributes.fashionColor": fake.Color().ColorName(),
-		"address.buildingNumber":  fake.Address().BuildingNumber(),
+		"fullName": fake.Person().FirstName() + " " + fake.Person().LastName(),
+		"sex":      fake.Person().Gender(),
+		"contact":  fake.Person().Contact().Phone,
 	}
 }

--- a/internal/template/template_person.go
+++ b/internal/template/template_person.go
@@ -208,11 +208,8 @@ func (p *Person) Compare(document1 interface{}, document2 interface{}) (bool, er
 
 func (p *Person) GenerateSubPathAndValue(fake *faker.Faker) map[string]any {
 	return map[string]interface{}{
-		"fullName":                fake.Person().FirstName() + " " + fake.Person().LastName(),
-		"sex":                     fake.Person().Gender(),
-		"contact.Phone":           fake.Person().Contact().Phone,
-		"contact.email":           fake.Person().Contact().Email,
-		"attributes.fashionColor": fake.Color().ColorName(),
-		"address.buildingNumber":  fake.Address().BuildingNumber(),
+		"fullName": fake.Person().FirstName() + " " + fake.Person().LastName(),
+		"sex":      fake.Person().Gender(),
+		"contact":  fake.Person().Contact().Phone,
 	}
 }


### PR DESCRIPTION
Updates :-
1. Refactor: Adjusted Person template to support sub doc operation properly and omitted to stop storing result immediately after operation.

Currently, some sub-doc path were nested part of some parent path.
Upon deletion of these sub-path the parent path still exists which don't fail the sub-doc read operation.
Removing such path will fail sub-doc read operations.

Changing stop storing result immediately after operation to build the correct result before saving it on disk.

2. Refactor: Implement mechanism to stop running tasks.

Develop a mechanism to halt ongoing Sirius tasks when clearing the global identifier associated with a specific test.