### PR TITLE
Adding support to pass argument -port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SERVER_REQUESTS_PATH=./internal/server_requests/server_requests_logs
 TASK_REQUEST_PATH=./internal/tasks/request_logs
 
 run: build
-	./${DOC_LOADER_SERVER}
+	./${DOC_LOADER_SERVER} -port "$(port)"
 
 deploy: build_sirius_for_docker
 	@echo "Stopping docker images (if running...)"

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/couchbaselabs/sirius/internal/server_requests"
 	"github.com/couchbaselabs/sirius/internal/sirius_documentation"
@@ -30,7 +31,11 @@ func set_port_to_use() {
 }
 
 func main() {
-	set_port_to_use()
+	flag.StringVar(&webPort, "port", "", "Port to listen")
+	flag.Parse()
+	if webPort == "" {
+		set_port_to_use()
+	}
 	registerInterfaces()
 
 	logFile, err := os.OpenFile(getFileName(), os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)


### PR DESCRIPTION
This will be taken priority over env variable SIRIUS_PORT.
So the priority goes like this,
   -port <N> OR ENV(SIRIUS_PORT) OR 4000 (default)